### PR TITLE
putting file's Path in quotes

### DIFF
--- a/src/main/java/redxax/oxy/explorer/FileExplorerScreen.java
+++ b/src/main/java/redxax/oxy/explorer/FileExplorerScreen.java
@@ -1192,7 +1192,8 @@ public class FileExplorerScreen extends Screen implements FileManager.FileManage
                         fileManager.deleteSelected(selectedPaths, currentPath);
                     }, deleteHoverColor);
                     Render.ContextMenu.addItem("Copy Path", () -> {
-                        minecraftClient.keyboard.setClipboard(entryData.path.toString());
+                        String quotedPath = "\"" + entryData.path.toString() + "\"";
+                        minecraftClient.keyboard.setClipboard(quotedPath); 
                         showNotification("Path copied", Notification.Type.INFO);
                     }, greenBright);
                     Render.ContextMenu.addItem("Refresh", () -> {


### PR DESCRIPTION
This modifies the "Copy Path" functionality to wrap the copied path in quotes because files with spaces in their name would mess up its path